### PR TITLE
Add the Namespace field to Libadwaita's package definition

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -7,10 +7,7 @@ import (
 	"github.com/diamondburned/gotk4/gir/cmd/gir-generate/genmain"
 )
 
-const (
-	gotk4Module   = "github.com/diamondburned/gotk4/pkg"
-	adwaitaModule = "github.com/diamondburned/gotk4-adwaita/pkg"
-)
+const adwaitaModule = "github.com/diamondburned/gotk4-adwaita/pkg"
 
 var Data = genmain.Overlay(
 	gendata.Main,

--- a/generator.go
+++ b/generator.go
@@ -15,8 +15,13 @@ const (
 var Data = genmain.Overlay(
 	gendata.Main,
 	genmain.Data{
-		Module:       adwaitaModule,
-		Packages:     []genmain.Package{{Name: "libadwaita-1"}},
+		Module: adwaitaModule,
+		Packages: []genmain.Package{
+			{
+				Name:       "libadwaita-1",
+				Namespaces: []string{"Adw-1"},
+			},
+		},
 		PkgGenerated: []string{"adw"},
 		PkgExceptions: []string{
 			"go.mod",


### PR DESCRIPTION
This PR fixes #7 

It adds the Adw-1 namespace to the package definition.
Now, the generator only outputs a module for the libadwaita package.
Until this patch, it generated modules for all packages in gendata.Main, which leads to failing verification.